### PR TITLE
Grafana firewall config: Remove port mapping for docker container

### DIFF
--- a/remote_files/docker-compose.yml
+++ b/remote_files/docker-compose.yml
@@ -44,7 +44,7 @@ services:
   grafana:
     image: ${DOCKER_USERNAME}/grafana_image:latest
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     networks:
       - minitwit-network
     volumes:


### PR DESCRIPTION
Now the grafana image should not expose any unnescessary ports - it is now bound to localhost